### PR TITLE
#167995948 Only admin will be able to change users to a mentor

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -1,10 +1,11 @@
 import express from 'express';
-import { json } from 'body-parser';
+import { json, urlencoded } from 'body-parser';
 import cors from 'cors';
 import masterRoute from './routes/masterRoute';
 
 const app = express();
 app.use(cors());
 app.use(json());
+app.use(urlencoded({ extended: true }));
 masterRoute(app);
 app.listen(3000);

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -1,6 +1,5 @@
 import { sign } from 'jsonwebtoken';
 import { Users } from '../models/myDb';
-import userApi from '../routes/userRoute/userEndPoint';
 
 class UserController {
   static singUp(req, res) {
@@ -14,25 +13,34 @@ class UserController {
       bio: req.body.bio,
       occupation: req.body.occupation,
       expertise: req.body.expertise,
+      user_role: 'user',
+      isAdmin: false,
       createdOn: new Date(),
     };
     Users.push(newUser);
-    sign({ id: newUser.id, email: newUser.email },
+    sign({ id: newUser.id, email: newUser.email, isAdmin: newUser.isAdmin },
       'secretkey', (errs, token) => {
         if (errs) return res.json({ err: errs });
         newUser.token = token;
-        return res.status(200).json({ data: { firstname: newUser.firstname, lastname: newUser.lastname, token: newUser.token } });
+        return res.status(201).json({ data: { firstname: newUser.firstname, lastname: newUser.lastname, token: newUser.token } });
       });
   }
 
   static signIn(req, res) {
     const signInUser = Users.find((user) => user.email === req.body.email);
     if (!signInUser) return res.status(401).json({ message: 'User not found' });
-    sign({ id: signInUser.id, email: signInUser.email }, 'secretkey', (errs, token) => {
+    sign({ id: signInUser.id, email: signInUser.email, isAdmin: signInUser.isAdmin }, 'secretkey', (errs, token) => {
       if (errs) return res.json({ err: errs });
       signInUser.token = token;
       return res.status(201).json({ data: { firstname: signInUser.firstname, lastname: signInUser.lastname, token: signInUser.token } });
     });
+  }
+
+  static changeUserToMentor(req, res) {
+    const singleUser = Users.find((user) => user.id === parseInt(req.params.userId, 10));
+    if (!singleUser) return res.status(404).json({ error: 'user not found' });
+    singleUser.user_role = req.body.user_role;
+    res.status(201).json({ message: 'user accunt changed to mentor' });
   }
 }
 

--- a/server/middleWare/userMiddleWare.js
+++ b/server/middleWare/userMiddleWare.js
@@ -1,0 +1,14 @@
+import { verify } from 'jsonwebtoken';
+
+class middleWareHandler {
+  static isAdminUser(req, res, next) {
+    if (!req.headers.authorization) return res.status(401).json({ error: 'You do not have an account' });
+    const token = req.headers.authorization.split(' ')[1];
+    const isAdminData = verify(token, 'secretkey');
+    req.userData = isAdminData;
+    if (isAdminData.isAdmin) return next();
+    return res.status(401).json({ error: 'You are not an admin' });
+  }
+}
+
+export default middleWareHandler;

--- a/server/models/myDb.js
+++ b/server/models/myDb.js
@@ -1,2 +1,16 @@
-export const Users = [];
+export const Users = [
+  {
+    id: 1,
+    firstname: 'munya',
+    lastname: 'eugene',
+    email: 'eu@gmail.com',
+    password: 'webapp12',
+    address: 'kigali,rwanda',
+    bio: 'leoum epasum',
+    occupation: 'minister',
+    expertise: 'leadership',
+    user_role: 'admin',
+    isAdmin: true,
+  },
+];
 export const Sessions = [];

--- a/server/routes/masterRoute.js
+++ b/server/routes/masterRoute.js
@@ -1,3 +1,4 @@
+
 import userEndPoint from './userRoute/userEndPoint';
 
 export default (app) => {

--- a/server/routes/userRoute/userEndPoint.js
+++ b/server/routes/userRoute/userEndPoint.js
@@ -1,9 +1,10 @@
 import express from 'express';
 import userHandler from '../../controllers/userController';
+import userMiddlewareHandler from '../../middleWare/userMiddleWare';
 
-const userApi = express.Router();
-
+const userApi = express.Router({ mergeParams: true });
 userApi.post('/auth/signup', userHandler.singUp);
 userApi.post('/auth/signin', userHandler.signIn);
+userApi.patch('/user/:userId', userMiddlewareHandler.isAdminUser, userHandler.changeUserToMentor);
 
 export default userApi;


### PR DESCRIPTION
#### What does this PR do?
Admin can change user to mentor
#### Description of Task to be completed?
Now an endpoint that an admin can use to change user to a mentor is working
#### How should this be manually tested?
After cloning this repo and installing dependencies locally in your computer you can test this url http://localhost:3000/api/v1/user/1 in your postman with patch method and {"user_role":"mentor"} in the body but remember to signup and user your token in header to be authenticated or login by using this credentials  {"email": "eu@gmail.com",	"password" :"webapp12"}
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167995948
#### Screenshots (if appropriate)
#### Questions: