### PR TITLE
#167996726 End point for a mentor to reject session request

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "bcrypt": "^3.0.6",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
+    "eslint-config-airbnb-base": "^14.0.0",
     "express": "^4.17.1",
     "joi": "^14.3.1",
     "jsonwebtoken": "^8.5.1"

--- a/server/controllers/sessionRequestController.js
+++ b/server/controllers/sessionRequestController.js
@@ -26,6 +26,13 @@ class sessionRequestHandler {
     singleSession.status = req.body.status;
     res.status(201).json({ data: singleSession });
   }
+
+  static rejectSession(req, res) {
+    const singleSession = Sessions.find((session) => session.id === parseInt(req.params.sessionId, 10));
+    if (!singleSession) return res.status(404).json({ data: singleSession });
+    singleSession.status = req.body.status;
+    res.status(201).json({ data: singleSession });
+  }
 }
 
 export default sessionRequestHandler;

--- a/server/routes/sessionRoute/sessionRoute.js
+++ b/server/routes/sessionRoute/sessionRoute.js
@@ -7,4 +7,6 @@ const sessionRoute = express.Router({ mergeParams: true });
 sessionRoute.post('/sessions', routeMiddleware.canViewAllMentors, sessionRequest.createSessionRequest);
 sessionRoute.get('/sessions', routeMiddleware.canViewAllMentors, sessionRequestHandler.viewAllSessions);
 sessionRoute.patch('/sessions/:sessionId/accept', routeMiddleware.isMentor, sessionRequestHandler.acceptSession);
+sessionRoute.patch('/sessions/:sessionId/reject', routeMiddleware.isMentor, sessionRequestHandler.rejectSession);
+
 export default sessionRoute;


### PR DESCRIPTION
#### What does this PR do?
Implement an endpoint for rejecting mentorship session request
#### Description of Task to be completed?
Creating PATCH /api/v1/sessions/sessionId/reject endpoint that let mentors reject a session requests
#### How should this be manually tested?
After making this repo running locally send a request via this url  http://localhost:3000/api/v1/sessions/1/reject through postman and {"status":"reject"} as the body without forgetting to attach your token captured from signup in header 
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
#### Screenshots (if appropriate)
#### Questions: