### PR TITLE
#168054326 Creat an endpoint for an admin to view all registered users

### DIFF
--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -59,8 +59,12 @@ class UserController {
 
   static userViewMentors(req, res) {
     const mentors = Users.filter((mentor) => mentor.user_role === 'mentor');
-    if (mentors.length === 0) return res.status(404).json({ message: 'No mentor found' });
     res.status(200).json({ data: mentors });
+  }
+
+  static adminViewUsers(req, res) {
+    const users = Users.filter((user) => user.user_role === 'user');
+    res.status(200).json({ data: users });
   }
 
   static viewSpecificMentor(req, res) {

--- a/server/models/myDb.js
+++ b/server/models/myDb.js
@@ -22,7 +22,7 @@ export const Users = [
     bio: 'leoum epasum',
     occupation: 'minister',
     expertise: 'leadership',
-    user_role: 'mentor',
+    user_role: 'user',
     isAdmin: false,
   },
 ];

--- a/server/routes/userRoute/userRoute.js
+++ b/server/routes/userRoute/userRoute.js
@@ -7,5 +7,6 @@ userRoute.post('/auth/signup', userHandler.singUp);
 userRoute.post('/auth/signin', userHandler.signIn);
 userRoute.patch('/user/:userId', userMiddlewareHandler.isAdminUser, userHandler.changeUserToMentor);
 userRoute.get('/mentors', userMiddlewareHandler.canViewAllMentors, userHandler.userViewMentors);
+userRoute.get('/users', userMiddlewareHandler.isAdminUser, userHandler.adminViewUsers);
 userRoute.get('/mentors/:mentorId', userMiddlewareHandler.canViewAllMentors, userHandler.viewSpecificMentor);
 export default userRoute;


### PR DESCRIPTION
#### What does this PR do?
Add an endpoint for retrieving all registered users
#### Description of Task to be completed?
GET /api/v1/users end point is created only admin will use it to see all registered users 
#### How should this be manually tested?
After making this repo running locally send a GET request via this url  http://localhost:3000/api/v1/users through postman without forgetting to attach your token captured from signup in header
#### Any background context you want to provide?
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168054326
#### Screenshots (if appropriate)
#### Questions: