### PR TITLE
#168284544 Allow authenticated user to change her/his profile

### DIFF
--- a/server/controllers/sessionRequestController.js
+++ b/server/controllers/sessionRequestController.js
@@ -69,6 +69,7 @@ class sessionRequestHandler {
   static editReview(req, res) {
     const review = Reviews.find((rev) => rev.id === parseInt(req.params.reviewId, 10) && rev.menteeId === req.authUser.id);
     if (!review) return res.status(404).json({ data: review });
+    review.score = req.body.score;
     review.remark = req.body.remark;
     res.status(201).json({ status: 201, data: review });
   }

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -90,6 +90,15 @@ class UserController {
     res.status(201).json({ status: 201, data: userFormat(singleUser) });
   }
 
+  static editUserProfile(req, res) {
+    const singleUser = Users.find((user) => user.id === parseInt(req.params.userId, 10));
+    singleUser.address = req.body.address;
+    singleUser.bio = req.body.bio;
+    singleUser.occupation = req.body.occupation;
+    singleUser.expertise = req.body.expertise;
+    res.status(201).json({ status: 201, data: userFormat(singleUser) });
+  }
+
   static userViewMentors(req, res) {
     const allMentors = [];
     const mentors = Users.filter((mentor) => mentor.user_role === 'mentor');

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -92,6 +92,7 @@ class UserController {
 
   static editUserProfile(req, res) {
     const singleUser = Users.find((user) => user.id === parseInt(req.params.userId, 10));
+    if (!singleUser) return res.status(404).json({ status: 404, message: 'User Not found', data: singleUser });
     singleUser.address = req.body.address;
     singleUser.bio = req.body.bio;
     singleUser.occupation = req.body.occupation;

--- a/server/helpers/mentorResponse.js
+++ b/server/helpers/mentorResponse.js
@@ -1,10 +1,8 @@
 export default (mentorReturnData) => ({
-  id: mentorReturnData.id,
   firstname: mentorReturnData.firstname,
   lastname: mentorReturnData.lastname,
   email: mentorReturnData.email,
   address: mentorReturnData.address,
-  user_role: mentorReturnData.user_role,
   bio: mentorReturnData.bio,
   occupation: mentorReturnData.occupation,
   expertise: mentorReturnData.expertise,

--- a/server/routes/userRoute/userRoute.js
+++ b/server/routes/userRoute/userRoute.js
@@ -9,4 +9,5 @@ userRoute.patch('/user/:userId', userMiddlewareHandler.isAdminUser, userHandler.
 userRoute.get('/mentors', userMiddlewareHandler.isUser, userHandler.userViewMentors);
 userRoute.get('/users', userMiddlewareHandler.isAdminUser, userHandler.adminViewUsers);
 userRoute.get('/mentors/:mentorId', userMiddlewareHandler.isUser, userHandler.viewSpecificMentor);
+userRoute.patch('/users/profile/:userId/edit', userHandler.editUserProfile);
 export default userRoute;

--- a/server/test/editUserProfile.test.js
+++ b/server/test/editUserProfile.test.js
@@ -1,0 +1,22 @@
+import { expect, use, request } from 'chai';
+import chaiHttp from 'chai-http';
+import server from '../server';
+
+use(chaiHttp);
+describe('User endpoints', () => {
+  it('admin change user to mentor', (done) => {
+    request(server).patch('/api/v1/users/profile/1/edit')
+      .send({
+        address: 'kigali,rwanda',
+        bio: 'loarem ipsum',
+        occupation: 'HOD',
+        expertise: 'food processing',
+      })
+      .end((err, res) => {
+        expect(res).to.have.status(201);
+        expect(res.body).to.have.property('data');
+        expect(res.body.data).to.be.an('object');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Change profile information
#### Description of Task to be completed?
PATCH /api/v1/users/profile/id/edit endpoint will be used to change profile information
#### How should this be manually tested?
After making this repo running locally send a PATCH request via this URL  http://localhost:5000/api/v1/users/profile/1/edit through postman and 
{
         "address": "kigali,Rwanda",
         " bio": "short_bio",
          "occupation": "myjob",
          "expertise": "your expertise"
	} as the body 
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168284544
#### Screenshots (if appropriate)
![Screenshot from 2019-09-04 12-16-48](https://user-images.githubusercontent.com/36619897/64246862-e9782380-cf0d-11e9-95d8-2c260a4b23ff.png)

#### Questions:
